### PR TITLE
Finals Time Migration to Crawler v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data
 .antlr
 *.log
 .vscode
+*/__pycache__

--- a/src/Parse.py
+++ b/src/Parse.py
@@ -23,6 +23,22 @@ class Parser:
     # Date format
     def setDateFormat(self, string: str):
         self.dateFormat = string
+    
+    def convertTimeGroup(self, time_group: str) -> str:
+        """
+        Converts a time group to a 24-hour format
+        eg: "10:20am - 2:50pm" -> "1020 - 1450"
+        """
+        matching_groups = re.findall(r"((\d{1,2}):(\d{2}) (a|p)m)", time_group)
+        if matching_groups == None or len(matching_groups) != 2: return "0000 - 0000"
+        converted_times = []
+        for time in matching_groups:
+            if len(time) != 4: return "0000 - 0000"
+            [_, hour, minute, ampm] = time
+            new_hour = str(int(hour) % 12 + (12 if ampm == 'p' else 0))
+            new_hour = new_hour if len(new_hour) == 2 else f"0{new_hour}"
+            converted_times.append(f"{new_hour}{minute}")
+        return " - ".join(converted_times)
 
     def parseBlock(self, block: pd.DataFrame) -> pd.DataFrame:
         """
@@ -51,7 +67,8 @@ class Parser:
         def time (n: re.Match):
             nonlocal sectionTime
             if sectionTime: return ""
-            sectionTime = n.group().lower()
+            group = n.group().lower()
+            sectionTime = self.convertTimeGroup(group)
             return ""
 
         for index, row in block.iterrows():
@@ -60,6 +77,7 @@ class Parser:
                 row[1] = dateSearch.sub(date, row[1])
                 row[1] = timeSearch.sub(time, row[1])
                 row[1] = hyphen.sub(" - ", row[1].lower())
+                row[1] = self.convertTimeGroup(row[1])
             except:
                 print(block)
                 print()
@@ -112,7 +130,7 @@ class Parser:
         df.columns=df.iloc[0, :]
         df.drop(inplace=True, index=0)
         df = df[['Course', 'Date', 'Time']]
-        df['Time'] = df['Time'].str.lower()
+        df['Time'] = df['Time'].str.lower().apply(self.convertTimeGroup)
         df = df.loc[df['Course'] != "None"]
 
         # Change date format from day, month date

--- a/src/Parse.py
+++ b/src/Parse.py
@@ -30,10 +30,10 @@ class Parser:
         eg: "10:20am - 2:50pm" -> "1020 - 1450"
         """
         matching_groups = re.findall(r"((\d{1,2}):(\d{2}) (a|p)m)", time_group)
-        if matching_groups == None or len(matching_groups) != 2: return "0000 - 0000"
+        if matching_groups == None or len(matching_groups) != 2: return "TBA"
         converted_times = []
         for time in matching_groups:
-            if len(time) != 4: return "0000 - 0000"
+            if len(time) != 4: return "TBA"
             [_, hour, minute, ampm] = time
             new_hour = str(int(hour) % 12 + (12 if ampm == 'p' else 0))
             new_hour = new_hour if len(new_hour) == 2 else f"0{new_hour}"

--- a/src/steps/parse.ts
+++ b/src/steps/parse.ts
@@ -173,7 +173,9 @@ export function parse(sections: SectionResponse[], version: number): TermData {
       );
       const periodIndex = cache(
         caches.periods,
-        `${meetingPart.meetingTime.beginTime} - ${meetingPart.meetingTime.endTime}`
+        meetingPart.meetingTime.beginTime && meetingPart.meetingTime.endTime
+          ? `${meetingPart.meetingTime.beginTime} - ${meetingPart.meetingTime.endTime}`
+          : "TBA"
       );
       const dateRangeIndex = cache(
         caches.dateRanges,
@@ -181,10 +183,10 @@ export function parse(sections: SectionResponse[], version: number): TermData {
       );
       const locationIndex = cache(caches.locations, location || null);
       const building =
-        meetingPart.meetingTime.buildingDescription === null &&
-        meetingPart.meetingTime.building === null
-          ? "TBA"
-          : `${meetingPart.meetingTime.buildingDescription} ${meetingPart.meetingTime.building}`;
+        meetingPart.meetingTime.buildingDescription &&
+        meetingPart.meetingTime.building
+          ? `${meetingPart.meetingTime.buildingDescription} ${meetingPart.meetingTime.building}`
+          : "TBA";
 
       // Set to -1 here and to be updated by Revise.py later
       const finalDateIndex = -1;


### PR DESCRIPTION
With the new Banner 9 API, each section has a new time format ("1450" instead of "2:50 PM"). However, the finals details pulled from Registrar's website still follow the old format. Due to this, sections were not being mapped to a finals time and were thus not being displayed in GT Scheduler's Finals tab.

### Changelog
- Changed the finals mapping to adhere to the new sections' time format 