### PR TITLE
Fixed Error in Fetching Courses From Banner

### DIFF
--- a/src/steps/details.ts
+++ b/src/steps/details.ts
@@ -33,20 +33,28 @@ export async function downloadCourseDetails(
   // (sometimes, we get rate limits/transport errors so this tries to mitigates them)
   const maxAttemptCount = 10;
   try {
-    const response = await backOff(() => axios.get<string>(url), {
-      // See https://github.com/coveooss/exponential-backoff for options API
-      jitter: "full",
-      numOfAttempts: maxAttemptCount,
-      retry: (err, attemptNumber) => {
-        error(`an error occurred while fetching details`, err, {
-          courseId,
-          url,
-          attemptNumber,
-          tryingAgain: attemptNumber < maxAttemptCount,
-        });
-        return true;
-      },
-    });
+    const response = await backOff(
+      () =>
+        axios.get<string>(url, {
+          headers: {
+            "User-Agent": "gt-scheduler/crawler",
+          },
+        }),
+      {
+        // See https://github.com/coveooss/exponential-backoff for options API
+        jitter: "full",
+        numOfAttempts: maxAttemptCount,
+        retry: (err, attemptNumber) => {
+          error(`an error occurred while fetching details`, err, {
+            courseId,
+            url,
+            attemptNumber,
+            tryingAgain: attemptNumber < maxAttemptCount,
+          });
+          return true;
+        },
+      }
+    );
     return response.data;
   } catch (err) {
     error(`exhausted retries for fetching details`, err, { courseId });
@@ -82,20 +90,28 @@ export async function downloadCoursePrereqDetails(
   // (sometimes, we get rate limits/transport errors so this tries to mitigates them)
   const maxAttemptCount = 10;
   try {
-    const response = await backOff(() => axios.get<string>(url), {
-      // See https://github.com/coveooss/exponential-backoff for options API
-      jitter: "full",
-      numOfAttempts: maxAttemptCount,
-      retry: (err, attemptNumber) => {
-        error(`an error occurred while fetching details`, err, {
-          courseId,
-          url,
-          attemptNumber,
-          tryingAgain: attemptNumber < maxAttemptCount,
-        });
-        return true;
-      },
-    });
+    const response = await backOff(
+      () =>
+        axios.get<string>(url, {
+          headers: {
+            "User-Agent": "gt-scheduler/crawler",
+          },
+        }),
+      {
+        // See https://github.com/coveooss/exponential-backoff for options API
+        jitter: "full",
+        numOfAttempts: maxAttemptCount,
+        retry: (err, attemptNumber) => {
+          error(`an error occurred while fetching details`, err, {
+            courseId,
+            url,
+            attemptNumber,
+            tryingAgain: attemptNumber < maxAttemptCount,
+          });
+          return true;
+        },
+      }
+    );
     return response.data;
   } catch (err) {
     error(`exhausted retries for fetching prereqs`, err, { courseId });

--- a/src/steps/download.ts
+++ b/src/steps/download.ts
@@ -53,21 +53,28 @@ export async function generateSearchSessionCookies(
     const response = await backOff(
       () =>
         axios
-          .post(
-            "https://registration.banner.gatech.edu/StudentRegistrationSsb/ssb/term/search?mode=search",
-            { term },
-            {
-              headers: {
-                "Content-Type": "application/x-www-form-urlencoded; charset=UT",
-                "User-Agent": "gt-scheduler/crawler",
-              },
-            }
+          .get(
+            "https://registration.banner.gatech.edu/StudentRegistrationSsb/ssb/classSearch/getTerms?searchTerm=&offset=0&max=1"
           )
-          .then((res) => {
+          .then(async (res) => {
             // Throws an error if session cookie generated is undefined to trigger a retry
             if (res.headers["set-cookie"] === undefined) {
-              throw new Error("Null session cookie generated");
+              throw new Error("Null session cookie generated in /getTerms");
             }
+
+            await axios.post(
+              "https://registration.banner.gatech.edu/StudentRegistrationSsb/ssb/term/search?mode=search",
+              { term },
+              {
+                headers: {
+                  "Content-Type":
+                    "application/x-www-form-urlencoded; charset=UTF-8",
+                  "User-Agent": "gt-scheduler/crawler",
+                  Cookie: res.headers["set-cookie"],
+                },
+              }
+            );
+
             return res;
           }),
       {

--- a/src/steps/download.ts
+++ b/src/steps/download.ts
@@ -8,7 +8,7 @@ import { error, span } from "../log";
 
 export const MAX_PAGE_SIZE = 500;
 export const MAX_ATTEMPT_COUNT = 10;
-export const PAGE_SIZE = 75; // Best runtime vs number of requests ratio
+export const PAGE_SIZE = 150; // Best runtime vs number of requests ratio
 
 export interface SectionsPage {
   sections: SectionResponse[];
@@ -54,7 +54,12 @@ export async function generateSearchSessionCookies(
       () =>
         axios
           .get(
-            "https://registration.banner.gatech.edu/StudentRegistrationSsb/ssb/classSearch/getTerms?searchTerm=&offset=0&max=1"
+            "https://registration.banner.gatech.edu/StudentRegistrationSsb/ssb/classSearch/getTerms?searchTerm=&offset=0&max=1",
+            {
+              headers: {
+                "User-Agent": "gt-scheduler/crawler",
+              },
+            }
           )
           .then(async (res) => {
             // Throws an error if session cookie generated is undefined to trigger a retry


### PR DESCRIPTION
Requests made to fetch the course sections from Banner (through the `StudentRegistrationSsb/ssb/searchResults/searchResults` endpoint) were failing because the Banner session was not being generated. The problem seems to have arisen due to Banner possibly changing the way the session is generated.

This PR fixes this bug by adding a request to the `StudentRegistrationSsb/ssb/classSearch/getTerms` endpoint to generate the session. Following are the new steps for grabbing sections from Banner:
1. `GET` request to `https://registration.banner.gatech.edu/StudentRegistrationSsb/ssb/classSearch/getTerms?searchTerm=&offset=0&max=1`
2. `POST` request to `https://registration.banner.gatech.edu/StudentRegistrationSsb/ssb/term/search?mode=search` with the cookie generated from (1) and the appropriate term in the request body
3. `GET` request to `https://registration.banner.gatech.edu/StudentRegistrationSsb/ssb/searchResults/searchResults` to fetch course information