### PR TITLE
added section specific titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It operates as a series of _steps_ that are processed after one another (see [`s
 
 In order to process the prerequisites data for each course (which comes in the form of a string like "Undergraduate Semester level CS 2340 Minimum Grade of C and Undergraduate Semester level LMC 3432 Minimum Grade of C" that can become much more complex), the crawler also utilizes an [ANTLR](https://www.antlr.org/) grammar and generated parser in order to convert the prerequisites data retrieved from Oscar into a normalized tree structure. The grammar itself and the generated parser/lexer code can be found in the [`src/steps/prereqs/grammar`](/src/steps/prereqs/grammar) folder.
 
-The crawler is run every 30 minutes using a [GitHub Action workflow](/.github/workflows/crawling.yml), which then publishes the resultant JSON to the `gh-pages` where it can be downloaded by the frontend app: https://gt-scheduler.github.io/crawler/202008.json.
+The crawler is run every 30 minutes using a [GitHub Action workflow](/.github/workflows/crawling.yml), which then publishes the resultant JSON to the `gh-pages` where it can be downloaded by the frontend app: https://gt-scheduler.github.io/crawler-v2/202308.json.
 
 ## 🚀 Running Locally
 

--- a/src/steps/parse.ts
+++ b/src/steps/parse.ts
@@ -221,10 +221,9 @@ export function parse(sections: SectionResponse[], version: number): TermData {
     });
 
     if (!(courseName in courses)) {
-      const title = courseTitle;
       const sectionsMap: Record<string, Section> = {};
       courses[courseName] = [
-        title,
+        courseTitle,
         sectionsMap,
         // Start off with an empty prerequisites array
         [],
@@ -241,6 +240,7 @@ export function parse(sections: SectionResponse[], version: number): TermData {
       campusIndex,
       attributeIndices,
       -1,
+      courseTitle,
     ];
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,8 @@ export interface Caches {
  */
 export type Course = [
   /**
-   * the full, human-readable name of the course (e.g. "Accounting I")
+   * the full, human-readable name of the course (e.g. "Accounting I"),
+   * (**Note** that this is simply the title of the first section added to sections)
    */
   fullName: string,
   /**
@@ -153,7 +154,12 @@ export type Section = [
    * integer index into caches.gradeBases,
    * specifying the grading scheme of the class
    */
-  gradeBaseIndex: number
+  gradeBaseIndex: number,
+  /**
+   * the full, human-readable name of the section (e.g. "Accounting I"),
+   * since sections within the same course can have different names
+   */
+  fullName: string
 ];
 
 /**


### PR DESCRIPTION
I noticed for CS 8803 the section title shown was not the sections actual title, it was whatever the first section for CS 8803's title was, which happened to be Computer Law or something.
![image](https://github.com/gt-scheduler/crawler-v2/assets/61996677/ead05904-b087-4e2e-be54-548088eca03b)

This is because the code only tracks a single title for the course itself, not specific sections. This PR adds that data to the crawler's section type.

Note: I had to add the extra field at the end of the tuple type for compatibility with GT scheduler's frontend parsing because tuples are parsed by their order, not the names of their field. This means you *should* be able to roll this change first, then roll this (TODO) PR to change the frontend. As a side-note, I think this is the disadvantage of using tuples, if these were records, it would likely be easier to upgrade the types.

This is what the final product looks like after both backend and frontend roll:
![image](https://github.com/gt-scheduler/crawler-v2/assets/61996677/fb245f63-8de8-4b6d-a9d0-a465505ba9bb)

Potential Future Work:
- You can see on the left pane it still just uses the first section's title for the title of the CS 8803 panel, but... I don't know what else you'd put there, ideally the words "Special Topics" would go there, but I'm not sure where that info is generally available. Regardless, this PR is an improvement.
- Roll the frontend PR afterwards