### PR TITLE
Fix missing location data for Rich Computer Center

### DIFF
--- a/src/steps/parse.ts
+++ b/src/steps/parse.ts
@@ -80,6 +80,8 @@ const courseLocations = new Map([
   ["Savant", new Location(33.772075, -84.395277)],
   ["ISyE Main", new Location(33.775178, -84.401879)],
   ["Fourth Street Houses", new Location(33.775381, -84.391451)],
+  ["Rich-Computer Center", new Location(33.775449, -84.395253)],
+  ["Rich Computer Center", new Location(33.775449, -84.395253)],
 ]);
 
 const ignoredLocations = [

--- a/src/steps/parse.ts
+++ b/src/steps/parse.ts
@@ -80,8 +80,8 @@ const courseLocations = new Map([
   ["Savant", new Location(33.772075, -84.395277)],
   ["ISyE Main", new Location(33.775178, -84.401879)],
   ["Fourth Street Houses", new Location(33.775381, -84.391451)],
-  ["Rich-Computer Center", new Location(33.775449, -84.395253)],
-  ["Rich Computer Center", new Location(33.775449, -84.395253)],
+  ["Rich-Computer Center", new Location(33.77535159008218, -84.39513500282604)],
+  ["Rich Computer Center", new Location(33.77535159008218, -84.39513500282604)],
 ]);
 
 const ignoredLocations = [


### PR DESCRIPTION
Resolves #37 

### Issue
Lat and long coordinates for the Rich Computer Center were missing in the parser which prevented it from rendering correctly on the map.

### Changes
- Transferred issue from website to crawler-v2
- Added the missing coordinates to `src/steps/parse.ts`
- Verified that the RCC appears correctly on the map

### Images
<img width="1686" height="980" alt="image" src="https://github.com/user-attachments/assets/5ece3ad1-c83c-4e9b-a4b4-cf2aeefd13c2" />

