### PR TITLE
Add debug information to crawler output (#36)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint \"src/**/*.ts\" --ignore-pattern \"src/steps/prereqs/grammar/**/*\"",
     "lint:fix": "eslint \"src/**/*.ts\" --ignore-pattern \"src/steps/prereqs/grammar/**/*\" --fix",
     "format": "prettier \"src/**/*.{ts,md,json}\" \"*.{ts,md,json}\" --write",
-    "format:check": "prettier \"src/**/*.{ts,md,json}\" \"*.{ts,md,json}\" --check"
+    "format:check": "prettier \"src/**/*.{ts,md,json}\" \"*.{ts,md,json}\" --check",
+    "debug": "ts-node src/debug.ts"
   },
   "dependencies": {
     "antlr4ts": "^0.5.0-alpha.3",

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,207 @@
+import path from "path";
+import fs from "fs/promises";
+import { existsSync, mkdirSync } from "fs";
+import { dataPath } from "./steps/write";
+import { Caches, TermData, Location, Prerequisites } from "./types";
+
+type MeetingDebug = {
+  periodIndex: number;
+  period: string;
+  days: string;
+  room: string;
+  locationIndex: number;
+  location: Location | null;
+  instructors: string[];
+  dateRangeIndex: number;
+  dateRange: string;
+  finalDateIndex: number;
+  finalDate: string | null;
+  finalTimeIdx: number;
+  finalTime: string | null;
+};
+
+type SectionDebug = {
+  crn: string;
+  meetings: MeetingDebug[];
+  creditHours: number;
+  scheduleTypeIndex: number;
+  scheduleType: string;
+  campusIndex: number;
+  campus: string;
+  attributeIndices: number[];
+  attributes: string[];
+  gradeBaseIndex: number;
+  gradeBase: string | null;
+};
+
+type CourseDebug = {
+  fullName: string;
+  sections: Record<string, SectionDebug>;
+  prerequisites: Prerequisites | [];
+  description: string | null;
+};
+
+type TermDebug = {
+  courses: Record<string, CourseDebug>;
+  caches: Caches;
+  updatedAt: string | Date;
+  version: number;
+};
+
+function safeGet<T>(arr: T[], idx: number): T | null {
+  if (idx == null || Number.isNaN(idx)) return null;
+  if (idx < 0 || idx >= arr.length) return null;
+  return arr[idx];
+}
+
+async function readJsonFile<T>(file: string): Promise<T> {
+  const buf = await fs.readFile(file, "utf8");
+  return JSON.parse(buf) as T;
+}
+
+async function writePrettyJson(file: string, data: unknown): Promise<void> {
+  const content = JSON.stringify(data, null, 2);
+  await fs.writeFile(file, `${content}\n`, "utf8");
+}
+
+function toDebugTerm(term: TermData): TermDebug {
+  const { caches } = term;
+
+  const courses: Record<string, CourseDebug> = {};
+
+  for (const [courseId, courseTuple] of Object.entries(term.courses)) {
+    const [fullName, sectionsMap, prerequisites, description] = courseTuple;
+
+    const sections: Record<string, SectionDebug> = {};
+    for (const [sectionId, sectionTuple] of Object.entries(sectionsMap)) {
+      const [
+        crn,
+        meetingsTuples,
+        creditHours,
+        scheduleTypeIndex,
+        campusIndex,
+        attributeIndices,
+        gradeBaseIndex,
+      ] = sectionTuple;
+
+      const scheduleType =
+        safeGet(caches.scheduleTypes, scheduleTypeIndex) ?? "";
+      const campus = safeGet(caches.campuses, campusIndex) ?? "";
+      const attributes = attributeIndices
+        .map((i) => safeGet(caches.attributes, i))
+        .filter((x): x is string => x != null);
+      const gradeBase =
+        gradeBaseIndex >= 0 ? safeGet(caches.gradeBases, gradeBaseIndex) : null;
+
+      const meetings: MeetingDebug[] = meetingsTuples.map((m) => {
+        const [
+          periodIndex,
+          days,
+          room,
+          locationIndex,
+          instructors,
+          dateRangeIndex,
+          finalDateIndex,
+          finalTimeIdx,
+        ] = m;
+
+        const period = safeGet(caches.periods, periodIndex) ?? "";
+        const dateRange = safeGet(caches.dateRanges, dateRangeIndex) ?? "";
+        const location = safeGet(caches.locations, locationIndex) ?? null;
+        const finalDate =
+          finalDateIndex >= 0
+            ? (safeGet(caches.finalDates, finalDateIndex) as
+                | string
+                | Date
+                | null)
+            : null;
+        const finalTime =
+          finalTimeIdx >= 0 ? safeGet(caches.finalTimes, finalTimeIdx) : null;
+
+        return {
+          periodIndex,
+          period,
+          days,
+          room,
+          locationIndex,
+          location,
+          instructors,
+          dateRangeIndex,
+          dateRange,
+          finalDateIndex,
+          finalDate: finalDate != null ? String(finalDate) : null,
+          finalTimeIdx,
+          finalTime,
+        };
+      });
+
+      sections[sectionId] = {
+        crn,
+        meetings,
+        creditHours,
+        scheduleTypeIndex,
+        scheduleType,
+        campusIndex,
+        campus,
+        attributeIndices,
+        attributes,
+        gradeBaseIndex,
+        gradeBase,
+      };
+    }
+
+    courses[courseId] = {
+      fullName,
+      sections,
+      prerequisites,
+      description,
+    };
+  }
+
+  return {
+    courses,
+    caches: term.caches,
+    updatedAt: term.updatedAt,
+    version: term.version,
+  };
+}
+
+async function ensureDebugDir(debugDir: string): Promise<void> {
+  if (!existsSync(debugDir)) mkdirSync(debugDir, { recursive: true });
+}
+
+async function listDataFiles(): Promise<string[]> {
+  const files = await fs.readdir(dataPath);
+  // Include only term JSON files like 202408.json, skip index.json and debug dir
+  const dataFileRegex = /^20\d{4}\.json$/;
+  return files
+    .filter((f) => dataFileRegex.test(f))
+    .map((f) => path.join(dataPath, f));
+}
+
+async function run(): Promise<void> {
+  const arg = process.argv[2]; // optional: specific file path or file name
+  const debugDir = path.join(dataPath, "debug");
+  await ensureDebugDir(debugDir);
+
+  const targets =
+    arg != null
+      ? [path.isAbsolute(arg) ? arg : path.join(dataPath, arg)]
+      : await listDataFiles();
+
+  for (const file of targets) {
+    const base = path.basename(file);
+    const out = path.join(debugDir, base);
+    const term = await readJsonFile<TermData>(file);
+    const debugTerm = toDebugTerm(term);
+    await writePrettyJson(out, debugTerm);
+    // eslint-disable-next-line no-console
+    console.log(`Wrote debug: ${out}`);
+  }
+}
+
+run().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
* Add debug script to transform indices to readable strings
* Add yarn debug command for easy execution
* Output human-readable JSON to data/debug/ directory

Resolves #36 
