### PR TITLE
Fix finals matrix for 2025 (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Then, to run the crawler, run:
 yarn start
 ```
 
-If you are using Windows use 
+If you are using Windows use
+
 ```
 yarn start:windows
 ```

--- a/src/Parse.py
+++ b/src/Parse.py
@@ -57,7 +57,7 @@ class Parser:
             if "Common Exams" in chunk.columns: df=chunk.copy()
         if df is None: return None
 
-        if self.year >= 2024:
+        if self.year == 2024:
           df.columns = ['Course', 'Date']
           df.drop(inplace=True, index=0)
           for index, row in df.iterrows(): 
@@ -239,7 +239,7 @@ class ParserV1(Parser):
         for idx, column in enumerate(block.columns):
             if titleSearch.match(column):
                 if idx == len(block.columns)-1: idxs.append([idx-1, idx])
-                elif "Exam Date/Time" in block.iloc[0, idx+1]:
+                elif isinstance(block.iloc[0, idx+1], str) and "Exam Date/Time" in block.iloc[0, idx+1]:
                     # Check if tabula created an extra column
                     idxs.append([idx-1, idx+1])
                 else: idxs.append([idx-1, idx])

--- a/src/Parse.py
+++ b/src/Parse.py
@@ -12,7 +12,6 @@ import PyPDF2
 from PyPDF2 import PdfReader
 import requests
 import os 
-import fitz
 
 # More documentation available: https://github.com/gt-scheduler/crawler/wiki/Finals-Scraping#revise
 

--- a/src/Parse.py
+++ b/src/Parse.py
@@ -24,7 +24,6 @@ timeSearch = re.compile(r"\d+:\d\d\s[PA]M\s*(‐|-)\s*\d+:\d\d [PA]M")
 titleSearch = re.compile(r"\d+:\d\d [AP]M\s+(‐|-)\s+\d+:\d\d\s[AP]M\sExams")
 
 class Parser:
-# TODO fix uneven boxes case. don't just ignore repeats, use the longer one. probably just better to use multi index
     def __init__(self):
         self.dateFormat = "%b %d, %Y"
         self.schedule = pd.DataFrame()

--- a/src/Revise.py
+++ b/src/Revise.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from Parse import ParserV1, ParserV2
+from Parse import ParserV1, ParserV2, ParserV3
 import json
 from typing import Tuple
 import pandas as pd
@@ -65,6 +65,14 @@ class Revise:
                     success = True
                 except Exception as e2:
                     print(f"ParserV2 also failed for {file.stem}: {e2}")
+                    try:
+                        # Fallback to ParserV3
+                        parser = ParserV3()
+                        parser.parseFile(file.stem)
+                        parser.parseCommon()
+                        success = True
+                    except Exception as e3:
+                        print(f"ParserV3 also failed for {file.stem}: {e3}")
 
             # Export the parsed data
             if success:

--- a/src/matrix.json
+++ b/src/matrix.json
@@ -3,5 +3,10 @@
   "202208": "https://registrar.gatech.edu/files/202208%20Final%20Exam%20Matrix.pdf",
   "202302": "https://registrar.gatech.edu/files/202302%20Final%20Exam%20Matrix.pdf",
   "202308": "https://registrar.gatech.edu/public/files/202308-Final-Exam-Matrix.pdf",
-  "202402": "https://registrar.gatech.edu/public/files/202402-Final-Exam-Matrix.pdf"
+  "202402": "https://registrar.gatech.edu/public/files/202402-Final-Exam-Matrix.pdf",
+  "202405": "https://registrar.gatech.edu/public/files/202405-Summer-Full-Final-Exam-Schedule.pdf",
+  "202408": "https://registrar.gatech.edu/public/files/202408%20Final%20Exam%20Matrix.pdf",
+  "202502": "https://registrar.gatech.edu/public/files/Final%20Exam%20Matrix%20for%20Spring%202025_0.pdf",
+  "202505": "https://registrar.gatech.edu/public/files/Summer%20Full%20202505_0.pdf",
+  "202508": "https://registrar.gatech.edu/public/files/Final%20Exam%20Matrix%20for%20Fall%202025_2.pdf"
 }


### PR DESCRIPTION
1. Added a V3 of finals matrix pdf that successfully parses 202502 by parsing the pdf in separate left and right halves (since tabula would sometimes combine left and right tables)
2. Modified Revise.py to try all three parsers for each semester
3. Cleaned up code in Parse.py 
4. Verified functionality for all semesters in matrix.json except for 202408 and 202405
5. Verified output locally:
<img width="1054" height="686" alt="Screenshot 2025-09-11 at 5 28 06 PM" src="https://github.com/user-attachments/assets/5b8c108c-817f-4722-895c-474cf1e166a6" />

NOTE: tabula is not able to parse pdfs consistently and there are many edge cases across the different semesters despite them all looking alike. this made it difficult to create a general-purpose parser, and there is no guarantee that the parser will work on future semesters :/

Resolves #35
