### PR TITLE
add tech square research building and student success center

### DIFF
--- a/src/steps/parse.ts
+++ b/src/steps/parse.ts
@@ -81,6 +81,11 @@ const courseLocations = new Map([
   ["ISyE Main", new Location(33.775178, -84.401879)],
   ["Fourth Street Houses", new Location(33.775381, -84.391451)],
   ["Rich-Computer Center", new Location(33.77535159008218, -84.39513500282604)],
+  [
+    "Tech Sq Research Bldg",
+    new Location(33.77739874937255, -84.39001672502131),
+  ],
+  ["Success Center", new Location(33.772459490136825, -84.39394154592185)],
 ]);
 
 const ignoredLocations = [


### PR DESCRIPTION
Previously classes in the Student Success Center or Tech Square Research Building showed up as undetermined. 
<img width="1101" height="356" alt="image" src="https://github.com/user-attachments/assets/1d521ceb-bcde-4a04-98ae-b26bd33c3c0c" />

<img width="1763" height="707" alt="image" src="https://github.com/user-attachments/assets/f1c49ca6-c897-427e-88a0-4a6442428a8d" />

This PR adds them to the crawler so they display.
<img width="687" height="462" alt="image" src="https://github.com/user-attachments/assets/730bf4bf-a181-40d9-ab78-15bbb67b112f" />

